### PR TITLE
Make debugger-for-chrome to a real dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
     "license": "SEE LICENSE IN LICENSE.txt",
     "dependencies": {
         "source-map": "^0.5.3",
-        "ws": "0.8.0"
+        "ws": "0.8.0",
+        "debugger-for-chrome": "Microsoft/vscode-chrome-debug#f3912e2"
     },
     "optionalDependencies": {
         "vs-libimobile" : "^0.0.3"
     },
     "devDependencies": {
-        "debugger-for-chrome": "Microsoft/vscode-chrome-debug#f3912e2",
         "gulp": "^3.9.0",
         "gulp-mocha": "^2.1.3",
         "gulp-sourcemaps": "^1.5.2",


### PR DESCRIPTION
debugger-for-chrome wasn't being installed correctly when bundling and packaging the extension.
